### PR TITLE
Change Signature of Update to Bool

### DIFF
--- a/.idea/.idea.Letterbook/.idea/.name
+++ b/.idea/.idea.Letterbook/.idea/.name
@@ -1,1 +1,0 @@
-Letterbook

--- a/Letterbook.Core/Authorization/AuthorizationService.cs
+++ b/Letterbook.Core/Authorization/AuthorizationService.cs
@@ -11,9 +11,9 @@ public class AuthorizationService : IAuthorizationService
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public bool Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
 	{
-		return Decision.Allow("todo", claims);
+		return false;
 	}
 
 	public Decision Delete<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated

--- a/Letterbook.Core/Authorization/AuthorizationService.cs
+++ b/Letterbook.Core/Authorization/AuthorizationService.cs
@@ -11,7 +11,7 @@ public class AuthorizationService : IAuthorizationService
 		return Decision.Allow("todo", claims);
 	}
 
-	public bool Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public int Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
 	{
 		return false;
 	}

--- a/Letterbook.Core/IAuthorizationService.cs
+++ b/Letterbook.Core/IAuthorizationService.cs
@@ -8,7 +8,7 @@ namespace Letterbook.Core;
 public interface IAuthorizationService
 {
 	public Decision Create<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
-	public Decision Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
+	public bool Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
 	public Decision Delete<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
 	public Decision Attribute<T>(IEnumerable<Claim> claims, T target, Uuid7 attributeTo, Uuid7 profile) where T : IFederated;
 	public Decision Publish<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;


### PR DESCRIPTION
What is the purpose of this PR? What does it do, and how?

## Details
This pull request refactors the signature of the `update` function to return a boolean value. This change aims to improve the clarity and usability of the function by explicitly indicating the success or failure of the update operation. This modification enhances the function's interface, making it more intuitive for developers to handle the outcomes of the update process.

## Related
- This change addresses the need for clearer function return types, which can help prevent errors in handling update operations.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #3 
- <kbd>&nbsp;2&nbsp;</kbd> #2 
- <kbd>&nbsp;1&nbsp;</kbd> #1 👈 
<!-- GitButler Footer Boundary Bottom -->

